### PR TITLE
add-custom-pr-title-capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
 |----------------------|--------------|---------|
 | `github_token` | **Required.** GitHub PAT token with repo access. | N/A |
 | `create-pull-request` | If `true`, creates a PR instead of committing directly. | `false` |
+| `pull-request-title` | Custom Title for PR | `Sync files [Automated]` |
 | `copy-from-directory` | Source directory to sync from. | `root-directory` |
 | `copy-to-directory` | Target directory in the destination repos. | `root-directory` |
 | `bot-name` | Customizable name for the committer bot | `syncbot` |
@@ -60,6 +61,7 @@ For large-scale repo management, you can use a **centralized JSON config** to de
     "repos": {
         "my-org/repo-one": {
             "create-pull-request": "true",
+             "pull-request-title": "[Jira-Ticket]-title-for-the-automated-PR",
             "copy-from-directory": "source-configs",
             "copy-to-directory": "configs"
         },

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,11 @@ inputs:
     description: "Set to true to create a PR instead of direct commit"
     required: false
     default: "false"
+  
+  pull-request-title:
+    description: "Title for the PR ceated (default: Sync files [Automated])"
+    required: false
+    default: "Sync files [Automated]"
 
   copy-from-directory:
     description: "Directory to copy files from (default: root level of source repo)"
@@ -65,3 +70,4 @@ runs:
         BOT_NAME: ${{ inputs.bot-name }}
         BOT_EMAIL: ${{ inputs.bot-email }}
         CONFIG_FILE: ${{ inputs.configs-json-file }}
+        PULL_REQUEST_TITLE: ${{ inputs.pull-request-title }}

--- a/sample_sync_configs.json
+++ b/sample_sync_configs.json
@@ -14,7 +14,8 @@
         "repo_three": {
             "copy-from-directory": "def/path/",
             "copy-to-directory": "def/path/",
-            "create-pull-request": "true"
+            "create-pull-request": "true",
+            "pull-request-title": "custom-title-for-the-PR"
         }
     }
 }

--- a/sync_files.py
+++ b/sync_files.py
@@ -10,6 +10,7 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 BOT_NAME = os.getenv("BOT_NAME", "").strip() or "syncbot"
 BOT_EMAIL = os.getenv("BOT_EMAIL", "").strip() or "syncbot@github.com"
 CONFIG_FILE = os.getenv("CONFIG_FILE", "").strip() or "sync_configs.json"
+PULL_REQUEST_TITLE = os.getenv("PULL_REQUEST_TITLE", "Sync files [Automated]").strip() # Basic initialization for pylint quirks
 
 # GitHub API Headers
 HEADERS = {

--- a/sync_files.py
+++ b/sync_files.py
@@ -126,7 +126,7 @@ def update_files_in_repo(target_repo, target_branch):
 def create_pull_request(target_repo, base_branch, head_branch):
     url = f"https://api.github.com/repos/{target_repo}/pulls"
     payload = {
-        "title": "Sync files [Automated]",
+        "title": PULL_REQUEST_TITLE,
         "head": head_branch,
         "base": base_branch,
         "body": "This PR updates multiple files in the repository."
@@ -176,6 +176,12 @@ for repo,configs in repos_config.items():
 
     if default_branch:   
         if CREATE_PR:
+            if "pull-request-title" in configs:
+                PULL_REQUEST_TITLE = configs["pull-request-title"]
+            else:
+                PULL_REQUEST_TITLE = os.getenv("PULL_REQUEST_TITLE", "Sync files [Automated]").strip()
+
+            print(f"CREATE_PR: {CREATE_PR}")
             feature_branch = create_feature_branch(repo, default_branch)
             if feature_branch:
                 update_files_in_repo(repo, feature_branch)


### PR DESCRIPTION
- This gives the users flexibility to have custom PR titles instead of having a default title in each repository each time a sync is made
- Improves GitHub history readability with task specific titles vs a PR with title "Sync files [Automated]" each time.
- Configurable at a repository level using the sync-config.json file
- Gives option to the users in an organization to attach work items in the title like Jira Issue ID